### PR TITLE
Feature/sqlite search filter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     implementation  'com.squareup.retrofit2:converter-gson:2.3.0'
 
     implementation "com.squareup.retrofit2:adapter-rxjava2:2.3.0"
-    implementation  "io.reactivex.rxjava2:rxandroid:2.0.1"
+    implementation  "io.reactivex.rxjava2:rxandroid:2.1.1"
 
     implementation  'com.squareup.okhttp3:logging-interceptor:3.9.1'
     implementation  'com.squareup.okhttp3:okhttp:3.9.1'

--- a/app/src/androidTest/java/com/applego/oblog/tppwatch/tpps/TppsActivityTest.kt
+++ b/app/src/androidTest/java/com/applego/oblog/tppwatch/tpps/TppsActivityTest.kt
@@ -196,7 +196,7 @@ class TppsActivityTest {
     fun markTppAsActiveOnDetailScreen_tppIsActiveInList() {
         // Add 1 followed tpp
         val tppTitle = "ACTIVE"
-        repository.saveTppBlocking(Tpp("Entity_CZ28173281", tppTitle, "DESCRIPTION", true))
+        repository.saveTppBlocking(Tpp("Entity_CZ28173281", tppTitle, "DESCRIPTION"))
 
         // start up Tpps screen
         val activityScenario = ActivityScenario.launch(TppsActivity::class.java)
@@ -252,7 +252,7 @@ class TppsActivityTest {
     fun markTppAsActiveAndFollowOnDetailScreen_tppIsFollowInList() {
         // Add 1 followed tpp
         val tppTitle = "COMP-ACT"
-        repository.saveTppBlocking(Tpp("Entity_CZ28173281", tppTitle, "DESCRIPTION", true))
+        repository.saveTppBlocking(Tpp("Entity_CZ28173281", tppTitle, "DESCRIPTION"))
 
         // start up Tpps screen
         val activityScenario = ActivityScenario.launch(TppsActivity::class.java)

--- a/app/src/main/java/com/applego/oblog/tppwatch/ServiceLocator.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/ServiceLocator.kt
@@ -67,7 +67,9 @@ object ServiceLocator {
         val result = Room.databaseBuilder(
             context.applicationContext,
             TppDatabase::class.java, "Tpps.db"
-        ).build()
+        )
+                .fallbackToDestructiveMigration()
+                .build()
         database = result
         return result
     }

--- a/app/src/main/java/com/applego/oblog/tppwatch/addedittpp/AddEditTppViewModel.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/addedittpp/AddEditTppViewModel.kt
@@ -25,7 +25,6 @@ import com.applego.oblog.tppwatch.R
 import com.applego.oblog.tppwatch.data.Result.Success
 import com.applego.oblog.tppwatch.data.source.local.Tpp
 import com.applego.oblog.tppwatch.data.source.TppsRepository
-import com.applego.oblog.tppwatch.data.source.local.RecordStatus
 import kotlinx.coroutines.launch
 
 /**
@@ -118,7 +117,7 @@ class AddEditTppViewModel(
         if (isNewTpp || currentTppId == null) {
             createTpp(Tpp("Entity_CZ28173282", currentTitle, currentDescription))
         } else {
-            val tpp = Tpp("Entity_CZ28173282", currentTitle, currentDescription, tppFollowed, "", RecordStatus.NEW, currentTppId)
+            val tpp = Tpp("Entity_CZ28173282", currentTitle, currentDescription, "", currentTppId)
             updateTpp(tpp)
         }
     }

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/TppsRepository.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/TppsRepository.kt
@@ -33,9 +33,9 @@ interface TppsRepository {
 
     suspend fun saveTpp(tpp: Tpp)
 
-    suspend fun unfollowTpp(tpp: Tpp)
-
     suspend fun followTpp(tppId: String)
+
+    suspend fun followTpp(tpp: Tpp)
 
     suspend fun activateTpp(tpp: Tpp)
 

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/TppsRepository.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/TppsRepository.kt
@@ -17,6 +17,7 @@
 package com.applego.oblog.tppwatch.data.source
 
 import com.applego.oblog.tppwatch.data.Result
+import com.applego.oblog.tppwatch.data.TppsFilter
 import com.applego.oblog.tppwatch.data.source.local.Tpp
 
 /**
@@ -26,11 +27,13 @@ interface TppsRepository {
 
     suspend fun getTpps(forceUpdate: Boolean = false): Result<List<Tpp>>
 
+    suspend fun getTpps(forceUpdate: Boolean, filter: TppsFilter): Result<List<Tpp>>
+
     suspend fun getTpp(tppId: String, forceUpdate: Boolean = false): Result<Tpp>
 
     suspend fun saveTpp(tpp: Tpp)
 
-    suspend fun unollowTpp(tpp: Tpp)
+    suspend fun unfollowTpp(tpp: Tpp)
 
     suspend fun followTpp(tppId: String)
 

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/LocalTppDataSource.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/LocalTppDataSource.kt
@@ -30,9 +30,9 @@ interface LocalTppDataSource {
 
     suspend fun saveTpp(tpp: Tpp)
 
-    suspend fun unfollowTpp(tpp: Tpp)
+    suspend fun followTpp(tpp: Tpp)
 
-    suspend fun unfollowTpp(tppId: String)
+    suspend fun followTpp(tppId: String)
 
     suspend fun activateTpp(tpp: Tpp)
 

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/LocalTppDataSource.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/LocalTppDataSource.kt
@@ -16,6 +16,7 @@
 package com.applego.oblog.tppwatch.data.source.local
 
 import com.applego.oblog.tppwatch.data.Result
+import com.applego.oblog.tppwatch.data.TppsFilter
 import com.applego.oblog.tppwatch.data.source.local.Tpp
 
 /**
@@ -23,7 +24,7 @@ import com.applego.oblog.tppwatch.data.source.local.Tpp
  */
 interface LocalTppDataSource {
 
-    suspend fun getTpps(): Result<List<Tpp>>
+    suspend fun getTpps(filter: TppsFilter): Result<List<Tpp>>
 
     suspend fun getTpp(tppId: String): Result<Tpp>
 

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/Tpp.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/Tpp.kt
@@ -36,10 +36,8 @@ data class Tpp @JvmOverloads constructor(
         @ColumnInfo(name = "entityCode") var entityCode: String = "",   // Entity Code retruned by EBA or NCA
         @ColumnInfo(name = "title") var title: String = "",             // Description  provided by original source. For additional details see detail
         @ColumnInfo(name = "description") var description: String = "",             // TPP is followed by user
-        @ColumnInfo(name = "followed") var isFollowed: Boolean = false,                 // A Global Unified identifier. Used by Preta as own ID.
-        @ColumnInfo(name = "globalUrn") var globalUrn: String = "",   // New, Updated, Removed (from original source), Deleted (From our DB) ...
-        @ColumnInfo(name = "status") var status: RecordStatus = RecordStatus.NEW,
-        @ColumnInfo(name = "ebaEntityVersion") var ebaEntityVersion: String = "",
+        @ColumnInfo(name = "globalUrn") var globalUrn: String = "",                 // A Global Unified identifier. Used by Preta as own ID.
+        @ColumnInfo(name = "ebaEntityVersion") var ebaEntityVersion: String = "",   // New, Updated, Removed (from original source), Deleted (From our DB) ...
         @PrimaryKey @ColumnInfo(name = "id") var id: String = UUID.randomUUID().toString()
         //val recipes: List<Recipe>
         // TODO#Define:
@@ -54,6 +52,18 @@ data class Tpp @JvmOverloads constructor(
 
     //var ebaEntityVersion: String = ""
         //get() = if (dateAcquired != null) dateAcquired else Date()
+
+    @ColumnInfo(name = "followed")
+    var isFollowed: Boolean = false
+
+    @ColumnInfo(name = "status")
+    var status: RecordStatus = RecordStatus.NEW
+
+    @ColumnInfo(name = "country")
+    var country: String = ""
+
+    //@ColumnInfo(name = "service")
+    //var ebaServices: List<EbaService>? = null
 
     val titleForList: String
         get() = if (title.isNotEmpty()) title else description

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/TppDatabase.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/TppDatabase.kt
@@ -25,7 +25,7 @@ import androidx.room.RoomDatabase
  * Note that exportSchema should be true in production databases.
  */
 // TODO: Set schema export to true and provide `room.schemaLocation` annotation processor argument
-@Database(entities = [Tpp::class, Service::class, Role::class, App::class], version = 6, exportSchema = false)
+@Database(entities = [Tpp::class, Service::class, Role::class, App::class], version = 7, exportSchema = false)
 abstract class TppDatabase : RoomDatabase() {
 
     abstract fun tppDao(): TppsDao

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/TppsDao.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/TppsDao.kt
@@ -110,4 +110,7 @@ interface TppsDao {
      */
     @Query("DELETE FROM Tpps WHERE followed = 1")
     suspend fun deleteUnfollowedTpps(): Int
+
+    @Query("SELECT * FROM Tpps WHERE country = :country")
+    fun getTppsByCountry(country: String): List<Tpp>
 }

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/TppsDaoDataSource.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/TppsDaoDataSource.kt
@@ -64,11 +64,11 @@ class TppsDaoDataSource internal constructor(
         tppsDao.insertTpp(tpp)
     }
 
-    override suspend fun unfollowTpp(tpp: Tpp) = withContext(ioDispatcher) {
+    override suspend fun followTpp(tpp: Tpp) = withContext(ioDispatcher) {
         tppsDao.updateFollowed(tpp.id, true)
     }
 
-    override suspend fun unfollowTpp(tppId: String) {
+    override suspend fun followTpp(tppId: String) {
         tppsDao.updateFollowed(tppId, true)
     }
 

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/TppsDaoDataSource.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/local/TppsDaoDataSource.kt
@@ -18,6 +18,7 @@ package com.applego.oblog.tppwatch.data.source.local
 import com.applego.oblog.tppwatch.data.Result
 import com.applego.oblog.tppwatch.data.Result.Error
 import com.applego.oblog.tppwatch.data.Result.Success
+import com.applego.oblog.tppwatch.data.TppsFilter
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -30,12 +31,20 @@ class TppsDaoDataSource internal constructor(
         private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : LocalTppDataSource {
 
-    override suspend fun getTpps(): Result<List<Tpp>> = withContext(ioDispatcher) {
+    override suspend fun getTpps(filter: TppsFilter): Result<List<Tpp>> = withContext(ioDispatcher) {
         return@withContext try {
+            var tpps: List<Tpp>
+            if (isOnlyCountry(filter)) {
+                tpps = tppsDao.getTppsByCountry(filter.country)
+            }
             Success(tppsDao.getTpps())
         } catch (e: Exception) {
             Error(e)
         }
+    }
+
+    private fun isOnlyCountry(filter: TppsFilter): Boolean {
+        return (!filter.country.isNullOrBlank() && filter.pasportedTo.isNullOrEmpty() && filter.services.isNullOrEmpty() && filter.tppName.isNullOrBlank());
     }
 
     override suspend fun getTpp(tppId: String): Result<Tpp> = withContext(ioDispatcher) {

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/remote/eba/TppDeserializer.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/remote/eba/TppDeserializer.kt
@@ -1,6 +1,5 @@
 package com.applego.oblog.tppwatch.data.source.remote.eba
 
-import com.applego.oblog.tppwatch.data.source.local.RecordStatus
 import com.applego.oblog.tppwatch.data.source.local.Tpp
 import com.google.gson.*
 import java.lang.reflect.Type
@@ -44,7 +43,7 @@ class TppDeserializer : JsonDeserializer<Tpp> {
         val status: String = jsonObject?.get("status")?.asString ?: ""
         val description: String = jsonObject?.get("description")?.asString ?: ""
 
-        return Tpp(entityCode, entityName, description, false, jsonObject?.get("globalUrn")?.asString ?:"", RecordStatus.getRecordStatus(status), ebaEntityVersion) //, entityId)
+        return Tpp(entityCode, entityName, description, jsonObject?.get("globalUrn")?.asString ?:"", ebaEntityVersion) //, entityId)
     }
 
     private fun getStringFromJsonArray(jsounArray: JsonArray): String {

--- a/app/src/main/java/com/applego/oblog/tppwatch/data/source/remote/eba/TppDeserializer.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/data/source/remote/eba/TppDeserializer.kt
@@ -50,8 +50,8 @@ class TppDeserializer : JsonDeserializer<Tpp> {
 
         var theString = ""
         for (jsonArrayElement:JsonElement in jsounArray) run {
-            theString += jsonArrayElement
-            theString += ", "
+            theString += jsonArrayElement.asString.removeSurrounding("\"")
+            theString += "\\"
         }
         return theString.trimEnd(',',' ')
     }

--- a/app/src/main/java/com/applego/oblog/tppwatch/tppdetail/TppDetailViewModel.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/tppdetail/TppDetailViewModel.kt
@@ -78,7 +78,7 @@ class TppDetailViewModel(
     fun setFollowed(follow: Boolean) = viewModelScope.launch {
         val tpp = _tpp.value ?: return@launch
         if (follow) {
-            tppsRepository.unollowTpp(tpp)
+            tppsRepository.followTpp(tpp.id)
             showSnackbarMessage(R.string.tpp_marked_followed)
         } else {
             tppsRepository.activateTpp(tpp)

--- a/app/src/main/java/com/applego/oblog/tppwatch/tppdetail/TppDetailViewModel.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/tppdetail/TppDetailViewModel.kt
@@ -78,7 +78,7 @@ class TppDetailViewModel(
     fun setFollowed(follow: Boolean) = viewModelScope.launch {
         val tpp = _tpp.value ?: return@launch
         if (follow) {
-            tppsRepository.followTpp(tpp.id)
+            tppsRepository.followTpp(tpp)
             showSnackbarMessage(R.string.tpp_marked_followed)
         } else {
             tppsRepository.activateTpp(tpp)

--- a/app/src/main/java/com/applego/oblog/tppwatch/tpps/TppsFragment.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/tpps/TppsFragment.kt
@@ -23,6 +23,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.SearchView
 import androidx.appcompat.widget.PopupMenu
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -39,6 +40,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import timber.log.Timber
 
+
 /**
  * Display a grid of [Tpp]s. User can choose to view all, active or followed tpps.
  */
@@ -51,6 +53,8 @@ class TppsFragment : Fragment() {
     private lateinit var viewDataBinding: TppsFragBinding
 
     private lateinit var listAdapter: TppsAdapter
+
+    private var searchView: SearchView? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -65,8 +69,8 @@ class TppsFragment : Fragment() {
 
     override fun onOptionsItemSelected(item: MenuItem) =
         when (item.itemId) {
-            R.id.menu_clear -> {
-                viewModel.clearFollowedTpps()
+            R.id.load_directory -> {
+                viewModel.loadEbaDirectory()
                 true
             }
             R.id.menu_filter -> {
@@ -74,7 +78,7 @@ class TppsFragment : Fragment() {
                 true
             }
             R.id.menu_refresh -> {
-                viewModel.loadTpps(true)
+                viewModel.loadTpps(false)
                 true
             }
             else -> false
@@ -93,11 +97,38 @@ class TppsFragment : Fragment() {
         setupListAdapter()
         setupRefreshLayout(viewDataBinding.refreshLayout, viewDataBinding.tppsList)
         setupNavigation()
+        setupTextSearch()
         setupFab()
 
         // Always reloading data for simplicity. Real apps should only do this on first load and
         // when navigating back to this destination. TODO: https://issuetracker.google.com/79672220
         //viewModel.loadTpps(true)
+    }
+
+    private fun setupTextSearch() {
+        searchView = activity?.findViewById<SearchView>(R.id.textSearchView)
+        if (searchView != null) {
+
+        }
+
+        searchView?.setIconifiedByDefault(true)
+        searchView?.setQueryHint("Type text to filter listed TPPs")
+        searchView?.setOnQueryTextFocusChangeListener { v, hasFocus ->
+            //TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+        // perform set on query text listener event
+        searchView?.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String): Boolean {
+                // do something on text submit
+                viewModel.filterByTitle(query)
+                return true
+            }
+
+            override fun onQueryTextChange(newText: String): Boolean {
+                // do something when text changes
+                return false
+            }
+        })
     }
 
     private fun setupNavigation() {
@@ -119,7 +150,7 @@ class TppsFragment : Fragment() {
     private fun showFilteringPopUpMenu() {
         val view = activity?.findViewById<View>(R.id.menu_filter) ?: return
         PopupMenu(requireContext(), view).run {
-            menuInflater.inflate(R.menu.filter_tpps, menu)
+            menuInflater.inflate(com.applego.oblog.tppwatch.R.menu.filter_tpps, menu)
 
             setOnMenuItemClickListener {
                 viewModel.setFiltering(

--- a/app/src/main/java/com/applego/oblog/tppwatch/tpps/TppsListBindings.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/tpps/TppsListBindings.kt
@@ -29,6 +29,7 @@ fun setItems(listView: RecyclerView, items: List<Tpp>) {
     (listView.adapter as TppsAdapter).submitList(items)
 }
 
+/*
 @BindingAdapter("app:followedTpp")
 fun setStyle(textView: TextView, enabled: Boolean) {
     if (enabled) {
@@ -36,4 +37,4 @@ fun setStyle(textView: TextView, enabled: Boolean) {
     } else {
         textView.paintFlags = textView.paintFlags and Paint.STRIKE_THRU_TEXT_FLAG.inv()
     }
-}
+}*/

--- a/app/src/main/java/com/applego/oblog/tppwatch/tpps/TppsViewModel.kt
+++ b/app/src/main/java/com/applego/oblog/tppwatch/tpps/TppsViewModel.kt
@@ -135,9 +135,9 @@ class TppsViewModel(
         }
     }
 
-    fun FollowTpp(tpp: Tpp, followed: Boolean) = viewModelScope.launch {
+    fun followTpp(tpp: Tpp, followed: Boolean) = viewModelScope.launch {
         if (followed) {
-            tppsRepository.unollowTpp(tpp)
+            tppsRepository.followTpp(tpp.id)
             showSnackbarMessage(R.string.tpp_marked_followed)
         } else {
             tppsRepository.activateTpp(tpp)

--- a/app/src/main/res/layout/tpp_item.xml
+++ b/app/src/main/res/layout/tpp_item.xml
@@ -56,6 +56,6 @@
             android:layout_marginStart="@dimen/activity_horizontal_margin"
             android:textAppearance="@style/TextAppearance.AppCompat.Title"
             android:text="@{tpp.titleForList}"
-            app:followedTpp="@{tpp.followed}" />
+             /> <!--app:followedTpp="@{tpp.followed}"-->
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/tpp_item.xml
+++ b/app/src/main/res/layout/tpp_item.xml
@@ -44,7 +44,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:onClick="@{(view) -> viewmodel.FollowTpp(tpp, ((CompoundButton)view).isChecked())}"
+            android:onClick="@{(view) -> viewmodel.followTpp(tpp, ((CompoundButton)view).isChecked())}"
             android:checked="@{tpp.followed}" />
 
         <TextView

--- a/app/src/main/res/layout/tpps_act.xml
+++ b/app/src/main/res/layout/tpps_act.xml
@@ -41,9 +41,26 @@
                 android:theme="@style/Toolbar"
                 app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
-            <SearchView
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                android:orientation="horizontal">
+
+                <SearchView
+                    android:id="@+id/textSearchView"
+                    android:layout_width="361dp"
+                    android:layout_height="match_parent">
+
+                </SearchView>
+
+                <ToggleButton
+                    android:id="@+id/resetSearch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/reset_name_filter" />
+
+            </LinearLayout>
 
         </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/tpps_frag.xml
+++ b/app/src/main/res/layout/tpps_frag.xml
@@ -66,7 +66,8 @@
                         android:layout_marginBottom="@dimen/activity_vertical_margin"
                         android:gravity="center_vertical"
                         android:text="@{context.getString(viewmodel.currentFilteringLabel)}"
-                        android:textAppearance="@style/TextAppearance.AppCompat.Title" />
+                        android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                        android:textSize="12sp" />
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/tpps_list"

--- a/app/src/main/res/menu/tpps_fragment_menu.xml
+++ b/app/src/main/res/menu/tpps_fragment_menu.xml
@@ -23,8 +23,8 @@
         android:icon="@drawable/ic_filter_list"
         app:showAsAction="always" />
     <item
-        android:id="@+id/menu_clear"
-        android:title="@string/menu_clear"
+        android:id="@+id/load_directory"
+        android:title="@string/load_eba_directory"
         app:showAsAction="never" />
     <item
         android:id="@+id/menu_refresh"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="loading_tpps_error">Error while loading tpps</string>
     <string name="followed_tpps_cleared">Followed tpps cleared</string>
     <string name="menu_filter">Filter</string>
-    <string name="menu_clear">Clear followed</string>
+    <string name="load_eba_directory">Load Eba Directory</string>
     <string name="menu_delete_tpp">Delete tpp</string>
     <string name="navigation_view_header_title">Tpp Watch</string>
     <string name="title_hint">Title</string>
@@ -64,4 +64,5 @@
 
     <string name="oblog_api_base_url">http://192.168.0.15:8585/eba-registry/</string>
 
+    <string name="reset_name_filter">Reset name filter</string>
 </resources>

--- a/app/src/prod/java/com/applego/oblog/tppwatch/data/TppsFilter.kt
+++ b/app/src/prod/java/com/applego/oblog/tppwatch/data/TppsFilter.kt
@@ -1,0 +1,36 @@
+package com.applego.oblog.tppwatch.data
+
+import com.applego.oblog.tppwatch.data.source.local.EbaService
+
+class TppsFilter {
+    var  tppName: String = ""
+    var  services: List<String>? = null
+    var  country: String = ""
+    var  pasportedTo: List<String>? = null
+    var  orderBy: String = ""
+
+    public fun withName(aName: String) : TppsFilter {
+        tppName = aName
+        return this;
+    }
+
+    public fun withServices(services: List<String>) : TppsFilter {
+        this.services = services
+        return this;
+    }
+
+    public fun withCountry(aCountry: String) : TppsFilter {
+        this.country = aCountry
+        return this;
+    }
+
+    public fun withPasportedTo(pasportedTo: List<String>) : TppsFilter {
+        this.pasportedTo = pasportedTo
+        return this;
+    }
+
+    public fun withOrderBy(orderBy: String) : TppsFilter {
+        this.orderBy = orderBy
+        return this;
+    }
+}

--- a/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/FakeRepository.kt
+++ b/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/FakeRepository.kt
@@ -19,6 +19,7 @@ import androidx.annotation.VisibleForTesting
 import com.applego.oblog.tppwatch.data.Result
 import com.applego.oblog.tppwatch.data.Result.Error
 import com.applego.oblog.tppwatch.data.Result.Success
+import com.applego.oblog.tppwatch.data.TppsFilter
 import com.applego.oblog.tppwatch.data.source.local.Tpp
 import java.util.LinkedHashMap
 
@@ -52,22 +53,25 @@ class FakeRepository : TppsRepository {
         return Success(tppsServiceData.values.toList())
     }
 
+    override suspend fun getTpps(forceUpdate: Boolean, filter: TppsFilter): Result<List<Tpp>> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
     override suspend fun saveTpp(tpp: Tpp) {
         tppsServiceData[tpp.id] = tpp
     }
 
-    override suspend fun unollowTpp(tpp: Tpp) {
-        val unfollowTpp = Tpp(tpp.entityCode, tpp.title, tpp.description, true, tpp.id)
+    override suspend fun unfollowTpp(tpp: Tpp) {
+        val unfollowTpp = Tpp(tpp.entityCode, tpp.title, tpp.description, tpp.id)
         tppsServiceData[tpp.id] = unfollowTpp
     }
 
     override suspend fun followTpp(tppId: String) {
-        // Not required for the remote data source.
-        throw NotImplementedError()
+        tppsServiceData[tppId]?.isFollowed = true
     }
 
     override suspend fun activateTpp(tpp: Tpp) {
-        val activeTpp = Tpp(tpp.entityCode, tpp.title, tpp.description, false, tpp.id)
+        val activeTpp = Tpp(tpp.entityCode, tpp.title, tpp.description, tpp.id)
         tppsServiceData[tpp.id] = activeTpp
     }
 

--- a/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/FakeRepository.kt
+++ b/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/FakeRepository.kt
@@ -61,13 +61,15 @@ class FakeRepository : TppsRepository {
         tppsServiceData[tpp.id] = tpp
     }
 
-    override suspend fun unfollowTpp(tpp: Tpp) {
-        val unfollowTpp = Tpp(tpp.entityCode, tpp.title, tpp.description, tpp.id)
-        tppsServiceData[tpp.id] = unfollowTpp
+    override suspend fun followTpp(tppId: String) {
+
+        val unfollowTpp = tppsServiceData[tppId] //Tpp(tppId.entityCode, tppId.title, tppId.description, tppId.id)
+        unfollowTpp?.isFollowed = true
+        //tppsServiceData[tppId.id] = unfollowTpp
     }
 
-    override suspend fun followTpp(tppId: String) {
-        tppsServiceData[tppId]?.isFollowed = true
+    override suspend fun followTpp(tpp: Tpp) {
+        tppsServiceData[tpp.id]?.isFollowed = true
     }
 
     override suspend fun activateTpp(tpp: Tpp) {

--- a/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/local/TppsDaoTest.kt
+++ b/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/local/TppsDaoTest.kt
@@ -86,7 +86,7 @@ class TppsDaoTest {
         database.tppDao().insertTpp(tpp)
 
         // When a tpp with the same id is inserted
-        val newTpp = Tpp("Entity_CZ28173282", "title2", "description2", true)
+        val newTpp = Tpp("Entity_CZ28173282", "title2", "description2")
         database.tppDao().insertTpp(newTpp)
 
         // THEN - The loaded data contains the expected values
@@ -121,7 +121,8 @@ class TppsDaoTest {
         database.tppDao().insertTpp(originalTpp)
 
         // When the tpp is updated
-        val updatedTpp = Tpp("Entity_CZ28173282", "new title", "new description", true, originalTpp.id, RecordStatus.UPDATED, originalTpp.ebaEntityVersion, originalTpp.id)
+        val updatedTpp = Tpp("Entity_CZ28173282", "new title", "new description", originalTpp.id, originalTpp.ebaEntityVersion, originalTpp.id)
+        updatedTpp.isFollowed = true
         database.tppDao().updateTpp(updatedTpp)
 
         // THEN - The loaded data contains the expected values
@@ -135,7 +136,7 @@ class TppsDaoTest {
     @Test
     fun updateFollowedAndGetById() = runBlockingTest {
         // When inserting a tpp
-        val tpp = Tpp("Entity_CZ28173281", "title", "description", true)
+        val tpp = Tpp("Entity_CZ28173281", "title", "description")
         database.tppDao().insertTpp(tpp)
 
         // When the tpp is updated
@@ -179,7 +180,9 @@ class TppsDaoTest {
     @Test
     fun deleteUnfollowedTppsAndGettingTpps() = runBlockingTest {
         // Given a followed tpp inserted
-        database.tppDao().insertTpp(Tpp("Entity_CZ28173281", "followed", "tpp", true))
+        var aTpp = Tpp("Entity_CZ28173281", "followed", "tpp")
+        aTpp.isFollowed = true // Followed is not set in constructor
+        database.tppDao().insertTpp(aTpp)
 
         // When deleting followed tpps
         database.tppDao().deleteUnfollowedTpps()

--- a/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/local/TppsLocalDataSourceTest.kt
+++ b/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/local/TppsLocalDataSourceTest.kt
@@ -99,7 +99,7 @@ class TppsLocalDataSourceTest {
         localDataSource.saveTpp(newTpp)
 
         // When followed in the persistent repository
-        localDataSource.unfollowTpp(newTpp)
+        localDataSource.followTpp(newTpp)
         val result = localDataSource.getTpp(newTpp.id)
 
         // Then the tpp can be retrieved from the persistent repository and is Followed
@@ -134,9 +134,9 @@ class TppsLocalDataSourceTest {
         val newTpp2 = Tpp("Entity_CZ28173282", "title2")
         val newTpp3 = Tpp("Entity_CZ28173283", "title3")
         localDataSource.saveTpp(newTpp1)
-        localDataSource.unfollowTpp(newTpp1)
+        localDataSource.followTpp(newTpp1)
         localDataSource.saveTpp(newTpp2)
-        localDataSource.unfollowTpp(newTpp2)
+        localDataSource.followTpp(newTpp2)
         localDataSource.saveTpp(newTpp3)
         // When followed tpps are cleared in the repository
         localDataSource.clearFollowedTpps()

--- a/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/local/TppsLocalDataSourceTest.kt
+++ b/app/src/sharedTest/java/com/applego/oblog/tppwatch/data/source/local/TppsLocalDataSourceTest.kt
@@ -22,6 +22,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import com.applego.oblog.tppwatch.MainCoroutineRule
 import com.applego.oblog.tppwatch.data.Result.Success
+import com.applego.oblog.tppwatch.data.TppsFilter
 import com.applego.oblog.tppwatch.data.succeeded
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -76,7 +77,8 @@ class TppsLocalDataSourceTest {
     @Test
     fun saveTpp_retrievesTpp() = runBlockingTest {
         // GIVEN - a new tpp saved in the database
-        val newTpp = Tpp("Entity_CZ28173281", "title", "description", true)
+        val newTpp = Tpp("Entity_CZ28173281", "title", "description")
+        newTpp.isFollowed = true
         localDataSource.saveTpp(newTpp)
 
         // WHEN  - Tpp retrieved by ID
@@ -110,7 +112,7 @@ class TppsLocalDataSourceTest {
     @Test
     fun activateTpp_retrievedTppIsActive() = runBlockingTest {
         // Given a new followed tpp in the persistent repository
-        val newTpp = Tpp("Entity_CZ28173281", "Some title", "Some description", true)
+        val newTpp = Tpp("Entity_CZ28173281", "Some title", "Some description")
         localDataSource.saveTpp(newTpp)
 
         localDataSource.activateTpp(newTpp)
@@ -162,7 +164,7 @@ class TppsLocalDataSourceTest {
         localDataSource.deleteAllTpps()
 
         // Then the retrieved tpps is an empty list
-        val result = localDataSource.getTpps() as Success
+        val result = localDataSource.getTpps(TppsFilter()) as Success
         assertThat(result.data.isEmpty(), `is`(true))
 
     }
@@ -176,7 +178,7 @@ class TppsLocalDataSourceTest {
         localDataSource.saveTpp(newTpp1)
         localDataSource.saveTpp(newTpp2)
         // Then the tpps can be retrieved from the persistent repository
-        val results = localDataSource.getTpps() as Success<List<Tpp>>
+        val results = localDataSource.getTpps(TppsFilter()) as Success<List<Tpp>>
         val tpps = results.data
         assertThat(tpps.size, `is`(2))
     }

--- a/app/src/sharedTest/java/com/applego/oblog/tppwatch/statistics/StatisticsFragmentTest.kt
+++ b/app/src/sharedTest/java/com/applego/oblog/tppwatch/statistics/StatisticsFragmentTest.kt
@@ -86,8 +86,11 @@ class StatisticsFragmentTest {
     fun tpps_showsNonEmptyMessage() {
         // Given some tpps
         repository.apply {
-            saveTppBlocking(Tpp("Entity_CZ28173281", "Title1", "Description1", false))
-            saveTppBlocking(Tpp("Entity_CZ28173282", "Title2", "Description2", true))
+            var tpp1 = Tpp("Entity_CZ28173281", "Title1", "Description1")
+            tpp1.isFollowed = true
+            saveTppBlocking(tpp1)
+            var tpp2 = Tpp("Entity_CZ28173282", "Title2", "Description2")
+            saveTppBlocking(tpp2)
         }
 
         val scenario = launchFragmentInContainer<StatisticsFragment>(Bundle(), R.style.AppTheme)
@@ -101,7 +104,6 @@ class StatisticsFragmentTest {
         onView(withId(R.id.stats_active_text)).check(matches(isDisplayed()))
         onView(withId(R.id.stats_active_text)).check(matches(withText(expectedActiveTppText)))
         onView(withId(R.id.stats_followed_text)).check(matches(isDisplayed()))
-        onView(withId(R.id.stats_followed_text))
-            .check(matches(withText(expectedFollowedTppText)))
+        onView(withId(R.id.stats_followed_text)).check(matches(withText(expectedFollowedTppText)))
     }
 }

--- a/app/src/sharedTest/java/com/applego/oblog/tppwatch/tppdetail/TppDetailFragmentTest.kt
+++ b/app/src/sharedTest/java/com/applego/oblog/tppwatch/tppdetail/TppDetailFragmentTest.kt
@@ -62,7 +62,7 @@ class TppDetailFragmentTest {
     @Test
     fun activeTppDetails_DisplayedInUi() {
         // GIVEN - Add active (unfollow) tpp to the DB
-        val activeTpp = Tpp("Entity_CZ28173281", "Active Tpp", "AndroidX Rocks", false)
+        val activeTpp = Tpp("Entity_CZ28173281", "Active Tpp", "AndroidX Rocks")
         repository.saveTppBlocking(activeTpp)
 
         // WHEN - Details fragment launched to display tpp
@@ -83,7 +83,8 @@ class TppDetailFragmentTest {
     @Test
     fun followedTppDetails_DisplayedInUi() {
         // GIVEN - Add followed tpp to the DB
-        val followedTpp = Tpp("Entity_CZ28173281", "Followed Tpp", "AndroidX Rocks", true)
+        var followedTpp = Tpp("Entity_CZ28173281", "Followed Tpp", "AndroidX Rocks")
+        followedTpp.isFollowed = true
         repository.saveTppBlocking(followedTpp)
 
         // WHEN - Details fragment launched to display tpp

--- a/app/src/sharedTest/java/com/applego/oblog/tppwatch/tpps/TppsFragmentTest.kt
+++ b/app/src/sharedTest/java/com/applego/oblog/tppwatch/tpps/TppsFragmentTest.kt
@@ -112,7 +112,9 @@ class TppsFragmentTest {
 
     @Test
     fun displayFollowedTpp() {
-        repository.saveTppBlocking(Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1", true))
+        var tpp1 = Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1")
+        tpp1.isFollowed = true
+        repository.saveTppBlocking(tpp1)
 
         launchActivity()
 
@@ -168,7 +170,8 @@ class TppsFragmentTest {
 
     @Test
     fun markTppAsFollowed() {
-        repository.saveTppBlocking(Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1"))
+        var tpp1 = Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1")
+        repository.saveTppBlocking(tpp1)
 
         launchActivity()
 
@@ -189,7 +192,8 @@ class TppsFragmentTest {
 
     @Test
     fun markTppAsActive() {
-        repository.saveTppBlocking(Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1", true))
+        var aTpp = Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1")
+        repository.saveTppBlocking(aTpp)
 
         launchActivity()
 
@@ -202,17 +206,17 @@ class TppsFragmentTest {
         onView(withText("TITLE1")).check(matches(isDisplayed()))
         onView(withId(R.id.menu_filter)).perform(click())
         onView(withText(R.string.nav_active)).perform(click())
-        onView(withText("TITLE1")).check(matches(isDisplayed()))
+        onView(withText("TITLE1")).check(matches(not(isDisplayed())))
         onView(withId(R.id.menu_filter)).perform(click())
         onView(withText(R.string.nav_followed)).perform(click())
-        onView(withText("TITLE1")).check(matches(not(isDisplayed())))
+        onView(withText("TITLE1")).check(matches(isDisplayed()))
     }
 
     @Test
     fun showAllTpps() {
         // Add one active tpp and one followed tpp
         repository.saveTppBlocking(Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1"))
-        repository.saveTppBlocking(Tpp("Entity_CZ28173282", "TITLE2", "DESCRIPTION2", true))
+        repository.saveTppBlocking(Tpp("Entity_CZ28173282", "TITLE2", "DESCRIPTION2"))
 
         launchActivity()
 
@@ -226,9 +230,14 @@ class TppsFragmentTest {
     @Test
     fun showActiveTpps() {
         // Add 2 active tpps and one followed tpp
-        repository.saveTppBlocking(Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1"))
-        repository.saveTppBlocking(Tpp("Entity_CZ28173282", "TITLE2", "DESCRIPTION2"))
-        repository.saveTppBlocking(Tpp("Entity_CZ28173283", "TITLE3", "DESCRIPTION3", true))
+        var tpp1 = Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1")
+        var tpp2 = Tpp("Entity_CZ28173282", "TITLE2", "DESCRIPTION2")
+        var tpp3 = Tpp("Entity_CZ28173283", "TITLE3", "DESCRIPTION3")
+        tpp3.isFollowed = true
+
+        repository.saveTppBlocking(tpp1)
+        repository.saveTppBlocking(tpp2)
+        repository.saveTppBlocking(tpp3)
 
         launchActivity()
 
@@ -243,9 +252,14 @@ class TppsFragmentTest {
     @Test
     fun showFollowedTpps() {
         // Add one active tpp and 2 followed tpps
-        repository.saveTppBlocking(Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1"))
-        repository.saveTppBlocking(Tpp("Entity_CZ28173282", "TITLE2", "DESCRIPTION2", true))
-        repository.saveTppBlocking(Tpp("Entity_CZ28173283", "TITLE3", "DESCRIPTION3", true))
+        var tpp1 = Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1")
+        var tpp2 = Tpp("Entity_CZ28173282", "TITLE2", "DESCRIPTION2")
+        tpp2.isFollowed = true
+        var tpp3 = Tpp("Entity_CZ28173283", "TITLE3", "DESCRIPTION3")
+        tpp3.isFollowed = true
+        repository.saveTppBlocking(tpp1)
+        repository.saveTppBlocking(tpp2)
+        repository.saveTppBlocking(tpp3)
 
         launchActivity()
 
@@ -260,8 +274,11 @@ class TppsFragmentTest {
     @Test
     fun clearFollowedTpps() {
         // Add one active tpp and one followed tpp
-        repository.saveTppBlocking(Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1"))
-        repository.saveTppBlocking(Tpp("Entity_CZ28173282", "TITLE2", "DESCRIPTION2", true))
+        var tpp1 = Tpp("Entity_CZ28173281", "TITLE1", "DESCRIPTION1")
+        var tpp2 = Tpp("Entity_CZ28173282", "TITLE2", "DESCRIPTION2")
+        tpp2.isFollowed = true;
+        repository.saveTppBlocking(tpp1)
+        repository.saveTppBlocking(tpp2)
 
         launchActivity()
 

--- a/app/src/sharedTest/java/com/applego/oblog/tppwatch/tpps/TppsFragmentTest.kt
+++ b/app/src/sharedTest/java/com/applego/oblog/tppwatch/tpps/TppsFragmentTest.kt
@@ -271,6 +271,7 @@ class TppsFragmentTest {
         onView(withText("TITLE3")).check(matches(isDisplayed()))
     }
 
+    /* TODO-REMOVE - Not needed as we don't clean followed TPPs. Instead this action is used to do full reload of EBA directory
     @Test
     fun clearFollowedTpps() {
         // Add one active tpp and one followed tpp
@@ -284,14 +285,14 @@ class TppsFragmentTest {
 
         // Click clear followed in menu
         openActionBarOverflowOrOptionsMenu(getApplicationContext())
-        onView(withText(R.string.menu_clear)).perform(click())
+        onView(withText(R.string.load_eba_directory)).perform(click())
 
         onView(withId(R.id.menu_filter)).perform(click())
         onView(withText(R.string.nav_all)).perform(click())
         // Verify that only the active tpp is shown
         onView(withText("TITLE1")).check(matches(isDisplayed()))
         onView(withText("TITLE2")).check(doesNotExist())
-    }
+    }*/
 
     @Test
     fun noTpps_AllTppsFilter_AddTppViewVisible() {

--- a/app/src/test/java/com/applego/oblog/tppwatch/FakeFailingTppsLocalDataSource.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/FakeFailingTppsLocalDataSource.kt
@@ -17,11 +17,12 @@
 package com.applego.oblog.tppwatch
 
 import com.applego.oblog.tppwatch.data.Result
+import com.applego.oblog.tppwatch.data.TppsFilter
 import com.applego.oblog.tppwatch.data.source.local.Tpp
 import com.applego.oblog.tppwatch.data.source.local.LocalTppDataSource
 
 object FakeFailingTppsLocalDataSource : LocalTppDataSource {
-    override suspend fun getTpps(): Result<List<Tpp>> {
+    override suspend fun getTpps(filter: TppsFilter): Result<List<Tpp>> {
         return Result.Error(Exception("Test"))
     }
 

--- a/app/src/test/java/com/applego/oblog/tppwatch/FakeFailingTppsLocalDataSource.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/FakeFailingTppsLocalDataSource.kt
@@ -34,11 +34,11 @@ object FakeFailingTppsLocalDataSource : LocalTppDataSource {
         TODO("not implemented")
     }
 
-    override suspend fun unfollowTpp(tpp: Tpp) {
+    override suspend fun followTpp(tpp: Tpp) {
         TODO("not implemented")
     }
 
-    override suspend fun unfollowTpp(tppId: String) {
+    override suspend fun followTpp(tppId: String) {
         TODO("not implemented")
     }
 

--- a/app/src/test/java/com/applego/oblog/tppwatch/FakeFailingTppsRemoteDataSource.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/FakeFailingTppsRemoteDataSource.kt
@@ -39,11 +39,11 @@ object FakeFailingTppsRemoteDataSource : RemoteTppDataSource {
         TODO("not implemented")
     }
 
-    override suspend fun unfollowTpp(tpp: Tpp) {
+    override suspend fun followTpp(tpp: Tpp) {
         TODO("not implemented")
     }
 
-    override suspend fun unfollowTpp(tppId: String) {
+    override suspend fun followTpp(tppId: String) {
         TODO("not implemented")
     }
 

--- a/app/src/test/java/com/applego/oblog/tppwatch/data/source/DefaultTppsRepositoryTest.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/data/source/DefaultTppsRepositoryTest.kt
@@ -195,7 +195,7 @@ class DefaultTppsRepositoryTest {
         assertThat((tppsRepository.getTpp(newTpp.id, true) as Success).data.isFollowed).isFalse()
 
         // Mark is as Followed
-        tppsRepository.followTpp(newTpp.id)
+        tppsRepository.followTpp(newTpp)
 
         // Verify it's now followed
         assertThat((tppsRepository.getTpp(newTpp.id) as Success).data.isFollowed).isTrue()
@@ -205,13 +205,13 @@ class DefaultTppsRepositoryTest {
     fun unfollowTpp_activeTppToServiceAPIUpdatesCache() = runBlockingTest {
         // Save a tpp
         tppsRepository.saveTpp(newTpp)
-        tppsRepository.followTpp(newTpp.id)
+        tppsRepository.followTpp(newTpp)
 
         // Make sure it's followed
         assertThat((tppsRepository.getTpp(newTpp.id, true) as Success).data.isActive).isFalse()
 
         // Mark is as active
-        tppsRepository.activateTpp(newTpp.id)
+        tppsRepository.activateTpp(newTpp)
 
         // Verify it's now activated
         val result = tppsRepository.getTpp(newTpp.id, true) as Success

--- a/app/src/test/java/com/applego/oblog/tppwatch/data/source/FakeLocalDataSource.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/data/source/FakeLocalDataSource.kt
@@ -19,11 +19,12 @@ package com.applego.oblog.tppwatch.data.source
 import com.applego.oblog.tppwatch.data.Result
 import com.applego.oblog.tppwatch.data.Result.Error
 import com.applego.oblog.tppwatch.data.Result.Success
+import com.applego.oblog.tppwatch.data.TppsFilter
 import com.applego.oblog.tppwatch.data.source.local.Tpp
 import com.applego.oblog.tppwatch.data.source.local.LocalTppDataSource
 
 class FakeLocalDataSource(var tpps: MutableList<Tpp>? = mutableListOf()) : LocalTppDataSource {
-    override suspend fun getTpps(): Result<List<Tpp>> {
+    override suspend fun getTpps(filter: TppsFilter): Result<List<Tpp>> {
         tpps?.let { return Success(it) }
         return Error(
             Exception("Tpps not found")

--- a/app/src/test/java/com/applego/oblog/tppwatch/data/source/FakeLocalDataSource.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/data/source/FakeLocalDataSource.kt
@@ -42,11 +42,11 @@ class FakeLocalDataSource(var tpps: MutableList<Tpp>? = mutableListOf()) : Local
         tpps?.add(tpp)
     }
 
-    override suspend fun unfollowTpp(tpp: Tpp) {
+    override suspend fun followTpp(tpp: Tpp) {
         tpps?.firstOrNull { it.id == tpp.id }?.let { it.isFollowed = true }
     }
 
-    override suspend fun unfollowTpp(tppId: String) {
+    override suspend fun followTpp(tppId: String) {
         tpps?.firstOrNull { it.id == tppId }?.let { it.isFollowed = true }
     }
 

--- a/app/src/test/java/com/applego/oblog/tppwatch/data/source/FakeRemoteDataSource.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/data/source/FakeRemoteDataSource.kt
@@ -47,11 +47,11 @@ class FakeRemoteDataSource(var tppsListResponse: TppsListResponse?/*MutableList<
         tpps?.add(tpp)
     }
 
-    override suspend fun unfollowTpp(tpp: Tpp) {
+    override suspend fun followTpp(tpp: Tpp) {
         tpps?.firstOrNull { it.id == tpp.id }?.let { it.isFollowed = true }
     }
 
-    override suspend fun unfollowTpp(tppId: String) {
+    override suspend fun followTpp(tppId: String) {
         tpps?.firstOrNull { it.id == tppId }?.let { it.isFollowed = true }
     }
 

--- a/app/src/test/java/com/applego/oblog/tppwatch/statistics/StatisticsUtilsTest.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/statistics/StatisticsUtilsTest.kt
@@ -29,7 +29,7 @@ class StatisticsUtilsTest {
     @Test
     fun getActiveAndFollowedStats_noFollowed() {
         val tpps = listOf(
-                Tpp("Entity_CZ28173281", "title", "desc", isFollowed = false)
+                Tpp("Entity_CZ28173281", "title", "desc")
         )
         // When the list of tpps is computed with an active tpp
         val result = getActiveAndFollowedStats(tpps)
@@ -41,8 +41,10 @@ class StatisticsUtilsTest {
 
     @Test
     fun getActiveAndFollowedStats_noActive() {
+        var tpp1 = Tpp("Entity_CZ28173281", "title", "desc")
+        tpp1.isFollowed = true
         val tpps = listOf(
-                Tpp("Entity_CZ28173281", "title", "desc", isFollowed = true)
+                tpp1
         )
         // When the list of tpps is computed with a followed tpp
         val result = getActiveAndFollowedStats(tpps)
@@ -55,12 +57,22 @@ class StatisticsUtilsTest {
     @Test
     fun getActiveAndFollowedStats_both() {
         // Given 3 followed tpps and 2 active tpps
+        var tpp1 = Tpp("Entity_CZ28173281", "title", "desc")
+            tpp1.isFollowed = true
+        var tpp2 = Tpp("Entity_CZ28173282", "title", "desc")
+            tpp2.isFollowed = true
+        var tpp3 = Tpp("Entity_CZ28173283", "title", "desc")
+            tpp3.isFollowed = true
+
+        var tpp4 = Tpp("Entity_CZ28173284", "title", "desc")
+        var tpp5 = Tpp("Entity_CZ28173285", "title", "desc")
+
         val tpps = listOf(
-                Tpp("Entity_CZ28173281", "title", "desc", isFollowed = true),
-                Tpp("Entity_CZ28173282", "title", "desc", isFollowed = true),
-                Tpp("Entity_CZ28173283", "title", "desc", isFollowed = true),
-                Tpp("Entity_CZ28173284", "title", "desc", isFollowed = false),
-                Tpp("Entity_CZ28173285", "title", "desc", isFollowed = false)
+                tpp1,
+                tpp2,
+                tpp3,
+                tpp4,
+                tpp5
         )
         // When the list of tpps is computed
         val result = getActiveAndFollowedStats(tpps)

--- a/app/src/test/java/com/applego/oblog/tppwatch/statistics/StatisticsViewModelTest.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/statistics/StatisticsViewModelTest.kt
@@ -72,9 +72,12 @@ class StatisticsViewModelTest {
     fun loadNonEmptyTppsFromRepository_NonEmptyResults() {
         // We initialise the tpps to 3, with one active and two followed
         val tpp1 = Tpp("Entity_CZ28173281", "Title1", "Description1")
-        val tpp2 = Tpp("Entity_CZ28173282", "Title2", "Description2", true)
-        val tpp3 = Tpp("Entity_CZ28173283", "Title3", "Description3", true)
-        val tpp4 = Tpp("Entity_CZ28173284", "Title4", "Description4", true)
+        tpp1.isFollowed = true
+        val tpp2 = Tpp("Entity_CZ28173282", "Title2", "Description2")
+        tpp2.isFollowed = true
+        val tpp3 = Tpp("Entity_CZ28173283", "Title3", "Description3")
+        tpp3.isFollowed = true
+        val tpp4 = Tpp("Entity_CZ28173284", "Title4", "Description4")
         tppsRepository.addTpps(tpp1, tpp2, tpp3, tpp4)
 
         // When loading of Tpps is requested

--- a/app/src/test/java/com/applego/oblog/tppwatch/tpps/TppViewModelTest.kt
+++ b/app/src/test/java/com/applego/oblog/tppwatch/tpps/TppViewModelTest.kt
@@ -166,13 +166,11 @@ class TppsViewModelTest {
         assertLiveDataEventTriggered(tppsViewModel.openTppEvent, tppId)
     }
 
+/*
     @Test
     fun clearFollowedTpps_clearsTpps() = mainCoroutineRule.runBlockingTest {
         // When followed tpps are cleared
-        tppsViewModel.clearFollowedTpps()
-
-        // Fetch tpps
-        tppsViewModel.loadTpps(true)
+        tppsViewModel.loadEbaDirectory()
 
         // Fetch tpps
         val allTpps = LiveDataTestUtil.getValue(tppsViewModel.items)
@@ -193,6 +191,7 @@ class TppsViewModelTest {
             tppsViewModel.snackbarText, R.string.followed_tpps_cleared
         )
     }
+*/
 
     @Test
     fun showEditResultMessages_editOk_snackbarUpdated() {


### PR DESCRIPTION
This PR misuses sqlite_search_filter branch name because it implements filtering of loaded TPPs by name substring. The filter is based on  SearchView widget and is implemented by a callback filtering ViewModels items by their name matching given string (caseinsensitive). SQLite (Room) database is left as is - and no queries are issued to it.